### PR TITLE
🏗 Make the dokku-update command a wee bit safer

### DIFF
--- a/dokku-update
+++ b/dokku-update
@@ -57,8 +57,10 @@ dokku-update-plugin() {
 }
 
 main() {
+  declare PROGRAM_NAME="$(basename "$0")"
   declare COMMAND="$1"
-  local DOKKU_DISTRO PLUGIN_NAME VERSION
+  declare PARAMETER="$2"
+  local DOKKU_DISTRO PLUGIN_NAME VERSION SYSTEM_UPDATES
 
   if [[ -f "/etc/os-release" ]]; then
     # shellcheck disable=SC1091
@@ -74,39 +76,65 @@ main() {
     exit 0
   fi
 
-  dokku-log-info "Running system updates"
-  case "$DOKKU_DISTRO" in
-    arch)
-      yay -Syyua
-      ;;
-    debian | ubuntu)
-      apt-get update -qq >/dev/null
-      apt-get -qq -y dist-upgrade
-      ;;
-    centos | opensuse | rhel)
-      dokku-log-warn "Updating this operating system is not supported"
-      ;;
-    *)
-      dokku-log-warn "Updating this operating system is not supported"
-      exit 1
-      ;;
-  esac
+  if [[ "$COMMAND" == "run" ]]; then
+    if [[ "$PARAMETER" == "-s" ]]; then
+      dokku-log-info "Running system updates"
+      SYSTEM_UPDATES=true
+    else
+      dokku-log-info "Updating Dokku"
+      SYSTEM_UPDATES=false
+    fi
 
-  # update all plugins
-  dokku-log-info "Updating all plugins"
-  for PLUGIN_NAME in $(dokku plugin:list | grep enabled | awk '$1=$1' | cut -d' ' -f1); do
-    dokku-update-plugin "$PLUGIN_NAME"
-  done
-  dokku plugin:install
+    case "$DOKKU_DISTRO" in
+      arch)
+        if [ "$SYSTEM_UPDATES" == true ]; then
+          yay -Syyua
+        else
+          yay -Syu docker-image-labeler dokku nginx plugn sshcommand
+        fi
+        ;;
+      debian | ubuntu)
+        apt-get update -qq >/dev/null
 
-  # rebuild all applications
-  dokku-log-info "Rebuilding all applications"
-  dokku ps:rebuild --all
+        if [ "$SYSTEM_UPDATES" == true ]; then
+          apt-get -qq -y dist-upgrade
+        else
+          apt-get install --only-upgrade docker-image-labeler dokku dokku-event-listener dokku-update gliderlabs-sigil herokuish nginx plugn sshcommand
+        fi
+        ;;
+      centos | opensuse | rhel)
+        dokku-log-warn "Updating this operating system is not supported"
+        exit 1
+        ;;
+      *)
+        dokku-log-warn "Updating this operating system is not supported"
+        exit 1
+        ;;
+    esac
 
-  dokku-log-info "Waiting for old containers to stop"
-  sleep 120
-  dokku-log-info "Cleaning up"
-  dokku cleanup --global
+    # update all plugins
+    dokku-log-info "Updating all plugins"
+    for PLUGIN_NAME in $(dokku plugin:list | grep enabled | awk '$1=$1' | cut -d' ' -f1); do
+      dokku-update-plugin "$PLUGIN_NAME"
+    done
+    dokku plugin:install
+
+    # rebuild all applications
+    dokku-log-info "Rebuilding all applications"
+    dokku ps:rebuild --all
+
+    dokku-log-info "Waiting for old containers to stop"
+    sleep 120
+    dokku-log-info "Cleaning up"
+    dokku cleanup --global
+  else
+    echo "Updates Dokku & its dependencies, all enabled plugins and rebuilds all Dokku apps. Optionally installs all other system updates."
+    echo
+    echo "Usage: $PROGRAM_NAME [run|version]"
+    echo "  Options:"
+    echo "    version    Prints version of $PROGRAM_NAME"
+    echo "    run        Triggers the update process; when invoked with optional -s argument, all system updates will be installed"
+  fi
 }
 
 main "$@"

--- a/dokku-update
+++ b/dokku-update
@@ -128,24 +128,30 @@ print-help() {
   echo "    run        Triggers the update process; when invoked with optional -s argument, all system updates will be installed"
 }
 
-main() {
-  declare COMMAND="$1"
+print-version() {
   local VERSION
 
-  if [[ "$COMMAND" == "version" ]] || [[ "$COMMAND" == "-v" ]]; then
-    VERSION=UNRELEASED
-    if [[ -f "/var/lib/dokku-update/VERSION" ]]; then
-      VERSION="$(cat /var/lib/dokku-update/VERSION)"
-    fi
-    echo "dokku-update ${VERSION}"
-    exit 0
+  VERSION=UNRELEASED
+  if [[ -f "/var/lib/dokku-update/VERSION" ]]; then
+    VERSION="$(cat /var/lib/dokku-update/VERSION)"
   fi
+  echo "dokku-update ${VERSION}"
+}
 
-  if [[ "$COMMAND" == "run" ]]; then
-    run-update "$@"
-  else
-    print-help
-  fi
+main() {
+  declare COMMAND="$1"
+
+  case "${COMMAND}" in
+    run)
+      run-update "$@"
+      ;;
+    version | -v)
+      print-version
+      ;;
+    *)
+      print-help
+      ;;
+  esac
 }
 
 main "$@"

--- a/dokku-update
+++ b/dokku-update
@@ -89,7 +89,7 @@ run-update() {
       if [ "$SYSTEM_UPDATES" == true ]; then
         apt-get -qq -y dist-upgrade
       else
-        apt-get install --only-upgrade docker-image-labeler dokku dokku-event-listener dokku-update gliderlabs-sigil herokuish nginx plugn sshcommand
+        apt-get -qq -y install --only-upgrade docker-image-labeler dokku dokku-event-listener dokku-update gliderlabs-sigil herokuish netrc nginx plugn procfile-util sshcommand
       fi
       ;;
     centos | opensuse | rhel)

--- a/dokku-update
+++ b/dokku-update
@@ -145,7 +145,7 @@ main() {
     run)
       run-update "$@"
       ;;
-    version | -v)
+    --version | version | -v)
       print-version
       ;;
     *)

--- a/dokku-update
+++ b/dokku-update
@@ -92,9 +92,21 @@ run-update() {
         apt-get -qq -y install --only-upgrade docker-image-labeler dokku dokku-event-listener dokku-update gliderlabs-sigil herokuish netrc nginx plugn procfile-util sshcommand
       fi
       ;;
-    centos | opensuse | rhel)
-      dokku-log-warn "Updating this operating system is not supported"
-      exit 1
+    centos | rhel)
+      if [ "$SYSTEM_UPDATES" == true ]; then
+        yum -y update
+      else
+        yum -y update bind-utils cpio curl dos2unix docker-image-labeler git gliderlabs-sigil jq man-db nc netrc nginx plugn procfile-util sshcommand sudo unzip
+      fi
+      ;;
+    opensuse)
+      zypper refresh
+
+      if [ "$SYSTEM_UPDATES" == true ]; then
+        zypper -n update
+      else
+        zypper -n update bind-utils cpio curl dos2unix docker-image-labeler git gliderlabs-sigil jq man-db nc netrc nginx plugn procfile-util sshcommand sudo unzip
+      fi
       ;;
     *)
       dokku-log-warn "Updating this operating system is not supported"

--- a/dokku-update
+++ b/dokku-update
@@ -56,7 +56,7 @@ dokku-update-plugin() {
   fi
 }
 
-main() {
+run-update() {
   declare PROGRAM_NAME="$(basename "$0")"
   declare COMMAND="$1"
   declare PARAMETER="$2"
@@ -66,6 +66,71 @@ main() {
     # shellcheck disable=SC1091
     DOKKU_DISTRO=$(. /etc/os-release && echo "$ID")
   fi
+
+  if [[ "$PARAMETER" == "-s" ]]; then
+    dokku-log-info "Running system updates"
+    SYSTEM_UPDATES=true
+  else
+    dokku-log-info "Updating Dokku"
+    SYSTEM_UPDATES=false
+  fi
+
+  case "$DOKKU_DISTRO" in
+    arch)
+      if [ "$SYSTEM_UPDATES" == true ]; then
+        yay -Syyua
+      else
+        yay -Syu docker-image-labeler dokku nginx plugn sshcommand
+      fi
+      ;;
+    debian | ubuntu)
+      apt-get update -qq >/dev/null
+
+      if [ "$SYSTEM_UPDATES" == true ]; then
+        apt-get -qq -y dist-upgrade
+      else
+        apt-get install --only-upgrade docker-image-labeler dokku dokku-event-listener dokku-update gliderlabs-sigil herokuish nginx plugn sshcommand
+      fi
+      ;;
+    centos | opensuse | rhel)
+      dokku-log-warn "Updating this operating system is not supported"
+      exit 1
+      ;;
+    *)
+      dokku-log-warn "Updating this operating system is not supported"
+      exit 1
+      ;;
+  esac
+
+  # update all plugins
+  dokku-log-info "Updating all plugins"
+  for PLUGIN_NAME in $(dokku plugin:list | grep enabled | awk '$1=$1' | cut -d' ' -f1); do
+    dokku-update-plugin "$PLUGIN_NAME"
+  done
+  dokku plugin:install
+
+  # rebuild all applications
+  dokku-log-info "Rebuilding all applications"
+  dokku ps:rebuild --all
+
+  dokku-log-info "Waiting for old containers to stop"
+  sleep 120
+  dokku-log-info "Cleaning up"
+  dokku cleanup --global
+}
+
+print-help() {
+  echo "Updates Dokku & its dependencies, all enabled plugins and rebuilds all Dokku apps. Optionally installs all other system updates."
+  echo
+  echo "Usage: $PROGRAM_NAME [run|version]"
+  echo "  Options:"
+  echo "    version    Prints version of $PROGRAM_NAME"
+  echo "    run        Triggers the update process; when invoked with optional -s argument, all system updates will be installed"
+}
+
+main() {
+  declare COMMAND="$1"
+  local VERSION
 
   if [[ "$COMMAND" == "version" ]] || [[ "$COMMAND" == "-v" ]]; then
     VERSION=UNRELEASED
@@ -77,63 +142,9 @@ main() {
   fi
 
   if [[ "$COMMAND" == "run" ]]; then
-    if [[ "$PARAMETER" == "-s" ]]; then
-      dokku-log-info "Running system updates"
-      SYSTEM_UPDATES=true
-    else
-      dokku-log-info "Updating Dokku"
-      SYSTEM_UPDATES=false
-    fi
-
-    case "$DOKKU_DISTRO" in
-      arch)
-        if [ "$SYSTEM_UPDATES" == true ]; then
-          yay -Syyua
-        else
-          yay -Syu docker-image-labeler dokku nginx plugn sshcommand
-        fi
-        ;;
-      debian | ubuntu)
-        apt-get update -qq >/dev/null
-
-        if [ "$SYSTEM_UPDATES" == true ]; then
-          apt-get -qq -y dist-upgrade
-        else
-          apt-get install --only-upgrade docker-image-labeler dokku dokku-event-listener dokku-update gliderlabs-sigil herokuish nginx plugn sshcommand
-        fi
-        ;;
-      centos | opensuse | rhel)
-        dokku-log-warn "Updating this operating system is not supported"
-        exit 1
-        ;;
-      *)
-        dokku-log-warn "Updating this operating system is not supported"
-        exit 1
-        ;;
-    esac
-
-    # update all plugins
-    dokku-log-info "Updating all plugins"
-    for PLUGIN_NAME in $(dokku plugin:list | grep enabled | awk '$1=$1' | cut -d' ' -f1); do
-      dokku-update-plugin "$PLUGIN_NAME"
-    done
-    dokku plugin:install
-
-    # rebuild all applications
-    dokku-log-info "Rebuilding all applications"
-    dokku ps:rebuild --all
-
-    dokku-log-info "Waiting for old containers to stop"
-    sleep 120
-    dokku-log-info "Cleaning up"
-    dokku cleanup --global
+    run-update "$@"
   else
-    echo "Updates Dokku & its dependencies, all enabled plugins and rebuilds all Dokku apps. Optionally installs all other system updates."
-    echo
-    echo "Usage: $PROGRAM_NAME [run|version]"
-    echo "  Options:"
-    echo "    version    Prints version of $PROGRAM_NAME"
-    echo "    run        Triggers the update process; when invoked with optional -s argument, all system updates will be installed"
+    print-help
   fi
 }
 


### PR DESCRIPTION
References dokku/dokku#4305

A few notes:

- I don’t have an Arch system readily available for testing so I kind of just hope that this is the command you’d use; list of dependencies taken from [AUR package](https://aur.archlinux.org/packages/dokku), but not sure if that’s correct – for example, there’s `dokku-event-listener` missing, is that expected?
- As for Ubuntu/Debian, I hope that these are all the packages that should stay up-to-date…
- And most critically, since my server is not yet ready for Dokku 0.24.0 (need to think about how to update Shinka for that first), I haven’t actually… tested the script beyond line 86 😬