### PR TITLE
Delete package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "dokku-update",
-  "version": "0.3.1",
-  "description": "Updates Dokku & its dependencies, all enabled plugins and rebuilds all Dokku apps. Optionally installs all other system updates",
-  "global": "true",
-  "install": "cp dokku-update /usr/local/bin && chmod +x /usr/local/bin/dokku-update",
-  "scripts": [ "dokku-update" ]
-}
-


### PR DESCRIPTION
This file is for bpkg, but that isn't needed for dokku-update since it is installed via apt.