### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
-
-## [0.3.0]

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2014 Jeff Lindsay
+Copyright (C) 2020 Jose Diaz-Gonzalez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = dokku-update
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.3.0
+BASE_VERSION ?= 0.3.1
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = dokku-update
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.3.1
+BASE_VERSION ?= 0.4.0
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = dokku-update
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.2.0
+BASE_VERSION ?= 0.3.0
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dokku-update",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Updates Dokku & its dependencies, all enabled plugins and rebuilds all Dokku apps. Optionally installs all other system updates",
   "global": "true",
   "install": "cp dokku-update /usr/local/bin && chmod +x /usr/local/bin/dokku-update",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dokku-update",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Updates Dokku & its dependencies, all enabled plugins and rebuilds all Dokku apps. Optionally installs all other system updates",
   "global": "true",
   "install": "cp dokku-update /usr/local/bin && chmod +x /usr/local/bin/dokku-update",

--- a/tests/unit/core.bats
+++ b/tests/unit/core.bats
@@ -1,0 +1,8 @@
+#!/usr/bin/env bats
+
+@test "(core) dokku-update help" {
+  run bash -c "dokku-update help | wc -l"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$output" -ge 7 ]]
+}

--- a/tests/unit/core.bats
+++ b/tests/unit/core.bats
@@ -4,5 +4,5 @@
   run bash -c "dokku-update help | wc -l"
   echo "output: $output"
   echo "status: $status"
-  [[ "$output" -ge 7 ]]
+  [[ "$output" -ge 6 ]]
 }


### PR DESCRIPTION
- #4: Update the release name and body after creation
- #5: Upgrade ci builder to ubuntu 20.04
- #6: Add Raspbian Bullseye as release target
- #7: Ensure version is properly printed on output
- #8: Drop unused changelog
-  #9: Delete package.json