### PR TITLE
Remove an unused variable and set a default shellcheckrc

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+disable=SC2034

--- a/dokku-update
+++ b/dokku-update
@@ -62,7 +62,7 @@ dokku-update-plugin() {
 
 run-update() {
   declare COMMAND="$1" PARAMETER="$2"
-  local DOKKU_DISTRO PLUGIN_NAME PROGRAM_NAME SYSTEM_UPDATES VERSION
+  local DOKKU_DISTRO PLUGIN_NAME PROGRAM_NAME SYSTEM_UPDATES
   PROGRAM_NAME="$(basename "$0")"
 
   if [[ -f "/etc/os-release" ]]; then


### PR DESCRIPTION
This ensures we can have some codebase quality without necessarily introducing tests.