### PR TITLE
chore: drop support for Ubuntu 20.04 Focal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,6 @@ release-packagecloud:
 	@$(MAKE) release-packagecloud-deb
 
 release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_all.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/noble build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_all.deb


### PR DESCRIPTION
Focal was EOL on May 31, 2025.