### PR TITLE
feat: publish deb packages to ubuntu/resolute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ release-packagecloud:
 release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/noble build/deb/$(NAME)_$(VERSION)_all.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/resolute build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bookworm build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/trixie build/deb/$(NAME)_$(VERSION)_all.deb


### PR DESCRIPTION
Dokku is adding Ubuntu 26.04 LTS ("Resolute Raccoon", codename `resolute`) support (ref: dokku/dokku#8768). This project's `.deb` packages are published to the `dokku/dokku` PackageCloud repository via the `release-packagecloud-deb` Makefile target, which previously pushed to `ubuntu/jammy` and `ubuntu/noble` but not `resolute`, leaving Ubuntu 26.04 users without a matching component to install from. This adds an `ubuntu/resolute` push line mirroring `ubuntu/noble` so tagged releases publish a 26.04 package.

Publishing the first 26.04 package still requires cutting a release: the `bump-version` workflow creates a tag, which triggers `tagged-release.yml` to push to PackageCloud.

Closes #209
