### PR TITLE
refactor: drop raspbian package publishing and runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,6 @@ release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bookworm build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/trixie build/deb/$(NAME)_$(VERSION)_all.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/bullseye build/deb/$(NAME)_$(VERSION)_all.deb
 
 validate: test
 	mkdir -p validation

--- a/dokku-update
+++ b/dokku-update
@@ -195,7 +195,7 @@ cmd-run() {
     arch)
       cmd-update-arch "$SYSTEM_UPDATES" "$DOKKU_TARGET_VERSION"
       ;;
-    debian | ubuntu | raspbian)
+    debian | ubuntu)
       cmd-update-apt "$SYSTEM_UPDATES" "$DOKKU_TARGET_VERSION"
       ;;
     opensuse)


### PR DESCRIPTION
Raspbian (Raspberry Pi OS 32-bit) is no longer a supported target, so tagged releases no longer publish a raspbian `.deb` to PackageCloud and the tool no longer treats a raspbian host as a supported platform when updating, reporting the standard unsupported operating system message instead.

Any raspbian packages already published to PackageCloud are unaffected by this change and would need to be removed manually if desired.

Closes #208